### PR TITLE
Feat: Use Bearer token

### DIFF
--- a/src/chat/chat.controller.ts
+++ b/src/chat/chat.controller.ts
@@ -1,4 +1,6 @@
-import { Controller } from '@nestjs/common';
+import { Controller, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
 
+@UseGuards(JwtAuthGuard)
 @Controller('chat')
 export class ChatController {}

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -6,10 +6,15 @@ import {
   Param,
   Put,
   Delete,
+  UseGuards,
 } from '@nestjs/common';
 import { UserService } from './user.service';
 import { UserDocument } from './schemas/user.schema';
+import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
+import { ApiBearerAuth } from '@nestjs/swagger';
 
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
 @Controller('users')
 export class UserController {
   constructor(private readonly userService: UserService) {}


### PR DESCRIPTION
## 추가한 점
- Swagger UI에서 Bearer token을 사용할 수 있도록 데코레이터 추가

## 수정한 점
- 로그인 시 json 포함, header에 `Authorization: Bearer ..` 파트가 추가되도록 수정
- `auth` 제외, 현재까지 추가해놓은 컨트롤러에 jwt 가드 추가