### PR TITLE
feat: 토큰 payload 및 채팅 관련 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,5 +56,5 @@ pids
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
-# Config
-jwt.dto.ts
+#
+**/configs

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ pids
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+
+# Config
+jwt.dto.ts

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,8 +1,10 @@
 import { Controller, Get, Request, UseGuards } from '@nestjs/common';
 import { AppService } from './app.service';
 import { JwtAuthGuard } from './auth/jwt-auth.guard';
+import { ApiTags } from '@nestjs/swagger';
 
 @Controller()
+@ApiTags('Test APIs')
 export class AppController {
   constructor(private readonly appService: AppService) {}
 

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,11 +1,13 @@
 import { Controller, Post, Body, Res } from '@nestjs/common';
 import { AuthService } from './auth.service';
-import { ApiBody } from '@nestjs/swagger';
+import { ApiBody, ApiTags } from '@nestjs/swagger';
 import { RegisterUserDto, LoginUserDto } from '../user/dtos/user.dto';
 import { UserService } from 'src/user/user.service';
 import { Response } from 'express';
+import { JwtTokenDto } from './jwt.dto';
 
 @Controller('auth')
+@ApiTags('Auth')
 export class AuthController {
   constructor(
     private authService: AuthService,
@@ -19,10 +21,15 @@ export class AuthController {
     if (!user) {
       return res.json('Invalid credentials');
     }
-    const jwt = await this.authService.login(user);
-    console.log(jwt);
+    console.log();
+    const payload: JwtTokenDto = {
+      id: user._id,
+      userId: user.userId,
+      username: user.username,
+    };
+    const jwt = await this.authService.login(payload);
     res.setHeader('Authorization', 'Bearer ' + jwt.access_token);
-    return res.json(jwt);
+    return res.status(200).json({ message: 'Login Successfully' });
   }
 
   @Post('register')

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -14,7 +14,7 @@ import { JwtStrategy } from './jwt.strategy';
     PassportModule,
     JwtModule.register({
       secret: 'secretKey',
-      signOptions: { expiresIn: '60s' },
+      signOptions: { expiresIn: '30m' }, // 환경변수 설정
     }),
     MongooseModule.forFeature([{ name: User.name, schema: UserSchema }]),
   ],

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,10 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
-import { User } from '../user/schemas/user.schema';
+import { User, UserDocument } from '../user/schemas/user.schema';
 import { UserService } from 'src/user/user.service';
 import * as bcrypt from 'bcrypt';
 import { RegisterUserDto } from '../user/dtos/user.dto';
-import { JwtTokenDto } from '../config/jwt.dto';
+import { JwtTokenDto } from './jwt.dto';
 
 @Injectable()
 export class AuthService {
@@ -19,8 +19,8 @@ export class AuthService {
       user &&
       (await this.userService.validatePassword(pass, user.password))
     ) {
-      const { password, ...result } = user;
-      return result;
+      const { _id, userId, username } = user;
+      return { _id, userId, username };
     }
     return null;
   }
@@ -32,7 +32,11 @@ export class AuthService {
   }
 
   async login(user: JwtTokenDto) {
-    const payload = { userId: user.userId, sub: user.username };
+    const payload = {
+      _id: user.id,
+      userId: user.userId,
+      username: user.username,
+    };
     return {
       access_token: this.jwtService.sign(payload),
     };

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -4,6 +4,7 @@ import { User } from '../user/schemas/user.schema';
 import { UserService } from 'src/user/user.service';
 import * as bcrypt from 'bcrypt';
 import { RegisterUserDto } from '../user/dtos/user.dto';
+import { JwtTokenDto } from '../config/jwt.dto';
 
 @Injectable()
 export class AuthService {
@@ -30,7 +31,7 @@ export class AuthService {
     return this.userService.create(user);
   }
 
-  async login(user: any) {
+  async login(user: JwtTokenDto) {
     const payload = { userId: user.userId, sub: user.username };
     return {
       access_token: this.jwtService.sign(payload),

--- a/src/auth/jwt.dto.ts
+++ b/src/auth/jwt.dto.ts
@@ -1,0 +1,14 @@
+import { IsBoolean, IsNotEmpty, IsString } from 'class-validator';
+import { Types } from 'mongoose';
+
+export class JwtTokenDto {
+  readonly id: Types.ObjectId;
+
+  @IsString()
+  @IsNotEmpty()
+  readonly userId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  readonly username: string;
+}

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
-import { AuthService } from './auth.service';
+import { JwtTokenDto } from './jwt.dto';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-  constructor(private authService: AuthService) {
+  constructor() {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
@@ -13,8 +13,8 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     });
   }
 
-  async validate(payload: any) {
+  async validate(payload: JwtTokenDto) {
     // payload에서 사용자 정보를 추출 후, 추가 검증을 수행 예정
-    return { userId: payload.userId, username: payload.sub };
+    return payload;
   }
 }

--- a/src/chat/chat.module.ts
+++ b/src/chat/chat.module.ts
@@ -1,9 +1,18 @@
 import { Module } from '@nestjs/common';
 import { ChatService } from './chat.service';
 import { ChatController } from './chat.controller';
+import { MongooseModule } from '@nestjs/mongoose';
+import { Chat, ChatSchema } from './schemas/chat.schema';
+import { Room, RoomSchema } from './schemas/room.schemas';
 
 @Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: Chat.name, schema: ChatSchema },
+      { name: Room.name, schema: RoomSchema },
+    ]),
+  ],
   providers: [ChatService],
-  controllers: [ChatController]
+  controllers: [ChatController],
 })
 export class ChatModule {}

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -1,4 +1,159 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Type } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Chat, ChatDocument } from './schemas/chat.schema';
+import { Model, Types } from 'mongoose';
+import { Room, RoomDocument } from './schemas/room.schemas';
+import {
+  ChatUserDto,
+  CreateRoomDto,
+  GetMessageDto,
+  MarkMessagesAsReadDto,
+  SendMessageDto,
+  UnreadMessageReqDto,
+  UnreadMessageResDto,
+} from './dtos/chat.dto';
 
 @Injectable()
-export class ChatService {}
+export class ChatService {
+  constructor(
+    @InjectModel(Chat.name) private chatModel: Model<ChatDocument>,
+    @InjectModel(Room.name) private roomModel: Model<RoomDocument>
+  ) {}
+
+  /**
+   *
+   * @param data
+   * @
+   * @returns
+   */
+  async createRoom(data: CreateRoomDto): Promise<RoomDocument> {
+    const { creator, isGroup, name, tags } = data;
+    const room = await this.roomModel.create({
+      participants: [creator],
+      name: name,
+      isGroup: isGroup,
+      tags: tags,
+      createdAt: new Date(),
+      lastReadMessage: { creator: null },
+    });
+    await room.save();
+    return room;
+  }
+
+  async participateChat(data: ChatUserDto): Promise<RoomDocument> {
+    const { roomId, userId } = data;
+    const room = await this.roomModel.findOne({ _id: roomId });
+    await room.participants.push(userId);
+    await room.lastReadMessage.set(userId, null);
+    await room.save();
+    return room;
+  }
+
+  /**
+   * 채팅방 입장 시 정해진 개수만큼 채팅 불러오기
+   * @param roomId
+   * @param limit
+   * @returns chats
+   */
+  async getMessages(data: GetMessageDto): Promise<ChatDocument[]> {
+    const { roomId, limit } = data;
+    const chats = await this.chatModel
+      .find({ _id: roomId })
+      .sort({ createdAt: 'ascending' })
+      .limit(limit)
+      .exec();
+    return chats;
+  }
+
+  async markMessagesAsRead(
+    message: MarkMessagesAsReadDto
+  ): Promise<RoomDocument> {
+    const { roomId, userId, lastMessageId } = message;
+    const room = await this.roomModel.findById(roomId);
+    room.lastReadMessage.set(userId, lastMessageId);
+    return await room.save();
+  }
+
+  async getUnreadMessageCount(
+    roomId: Types.ObjectId,
+    userId: Types.ObjectId
+  ): Promise<number> {
+    const room = await this.roomModel.findById(roomId).exec();
+    const lastReadMessageId = room.lastReadMessage.get(userId);
+    if (!lastReadMessageId) {
+      const unreadCount = await this.chatModel
+        .countDocuments({
+          roomId, // 읽은 message가 없다면
+        })
+        .exec();
+      return unreadCount;
+    }
+    const unreadCount = await this.chatModel
+      .countDocuments({
+        roomId,
+        _id: { $gt: lastReadMessageId }, // ObjectId 비교를 통해 계산
+      })
+      .exec();
+
+    // 사용자가 마지막으로 읽은 메시지 이후의 메시지 개수 계산
+    return unreadCount;
+  }
+
+  /**
+   * 각 채팅방 별 읽지 않은 메세지 수
+   * @param roomId
+   * @returns unreadCounts
+   */
+  async getUnreadCountForMessages(
+    data: UnreadMessageReqDto
+  ): Promise<UnreadMessageResDto> {
+    const roomId = data.roomId;
+    const room = await this.roomModel
+      .findById(roomId)
+      .populate('participants')
+      .exec();
+
+    // 해당 방에 존재하는 모든 메시지들을 가져옴
+    const messages = await this.chatModel
+      .find({ roomId })
+      .sort({ createdAt: 'ascending' })
+      .exec();
+
+    // 메시지별로 읽지 않은 사람 수를 저장할 객체
+    const unreadCounts: { [messageId: string]: number } = {};
+
+    // 방의 참여자 정보와 각 참여자의 마지막 읽은 메시지를 확인
+    for (const message of messages) {
+      console.log(message);
+      let unreadCount = 0;
+
+      for (const userId of room.participants) {
+        // 사용자의 마지막 읽은 메시지 ID
+        const lastReadMessageId = room.lastReadMessage.get(userId);
+
+        // lastReadMessageId가 없거나 현재 메시지 ID보다 이전이면 아직 읽지 않음
+        if (
+          !lastReadMessageId ||
+          (message._id as Types.ObjectId) > lastReadMessageId
+        ) {
+          unreadCount++;
+        }
+      }
+
+      // 메시지별로 읽지 않은 사람 수를 기록
+      unreadCounts[message._id as string] = unreadCount;
+    }
+
+    console.log(unreadCounts);
+    return unreadCounts;
+  }
+  // TODO: 전체 조회 시 count 갱신과 채팅 하나 입력마다 새로 계산되는 것 다르게 구현
+
+  async sendMessage(sended: SendMessageDto): Promise<ChatDocument> {
+    sended = {
+      ...sended,
+      createdAt: new Date(),
+    } as ChatDocument;
+    return await this.chatModel.create(sended);
+  }
+}

--- a/src/chat/dtos/chat.dto.ts
+++ b/src/chat/dtos/chat.dto.ts
@@ -1,16 +1,47 @@
+import { Types } from 'mongoose';
+
 export class CreateRoomDto {
-  participants: string[];
-  isGroupChat: boolean;
-  name?: string;
+  creator: Types.ObjectId;
+  isGroup: boolean;
+  name: string;
+  tags: string[];
 }
 
 export class SendMessageDto {
-  roomId: string;
-  senderId: string;
+  roomId: Types.ObjectId;
+  senderId: Types.ObjectId;
   message: string;
 }
 
+export class GetMessageDto {
+  roomId: Types.ObjectId;
+  limit: number;
+}
+
+export class ChatUserDto {
+  roomId: Types.ObjectId;
+  userId: Types.ObjectId;
+}
+
 export class MarkMessagesAsReadDto {
-  roomId: string;
-  userId: string;
+  roomId: Types.ObjectId;
+  userId: Types.ObjectId;
+  lastMessageId: Types.ObjectId;
+}
+
+export class UnreadChatReqDto {
+  roomId: Types.ObjectId;
+}
+
+export class UnreadChatResDto {
+  roomId: Types.ObjectId;
+  counts: number;
+}
+
+export class UnreadMessageReqDto {
+  roomId: Types.ObjectId;
+}
+
+export class UnreadMessageResDto {
+  [roomId: string]: number;
 }

--- a/src/chat/schemas/chat.schema.ts
+++ b/src/chat/schemas/chat.schema.ts
@@ -14,11 +14,8 @@ export class Chat {
   @Prop({ required: true })
   message: string;
 
-  @Prop({ default: Date.now })
+  @Prop({ default: Date.now() })
   createdAt: Date;
-
-  @Prop({ type: [Types.ObjectId], ref: 'User' })
-  readBy: Types.ObjectId[];
 }
 
 export const ChatSchema = SchemaFactory.createForClass(Chat);

--- a/src/chat/schemas/room.schemas.ts
+++ b/src/chat/schemas/room.schemas.ts
@@ -19,8 +19,11 @@ export class Room {
   @IsString()
   tags: string[];
 
-  @Prop({ default: Date.now })
+  @Prop({ default: new Date() })
   createdAt: Date;
+
+  @Prop({ type: Map, of: Types.ObjectId }) // 사용자별로 마지막 읽은 메시지 ID를 저장
+  lastReadMessage: Map<Types.ObjectId, Types.ObjectId>; // <사용자 ID, 메세지 ID>
 }
 
 export const RoomSchema = SchemaFactory.createForClass(Room);

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,13 +7,10 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
   const options = new DocumentBuilder()
-    .setTitle('Your API Title')
-    .setDescription('Your API description')
+    .setTitle('TagTing')
+    .setDescription('DevKor onboarding TEAM2 ')
     .setVersion('1.0')
     .addServer('http://localhost:3000/', 'Local environment')
-    .addServer('https://staging.yourapi.com/', 'Staging')
-    .addServer('https://production.yourapi.com/', 'Production')
-    .addTag('Your API Tag')
     .addBearerAuth()
     .build();
 

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -11,10 +11,11 @@ import {
 import { UserService } from './user.service';
 import { UserDocument } from './schemas/user.schema';
 import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
-import { ApiBearerAuth } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 
 @UseGuards(JwtAuthGuard)
 @ApiBearerAuth()
+@ApiTags('User APIs')
 @Controller('users')
 export class UserController {
   constructor(private readonly userService: UserService) {}

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -30,8 +30,8 @@ export class UserService {
     return this.userModel.find().exec();
   }
 
-  async findOne(id: string): Promise<User> {
-    return this.userModel.findOne({ userId: id }).exec();
+  async findOne(id: string): Promise<UserDocument> {
+    return await this.userModel.findOne({ userId: id }).exec();
   }
 
   async update(id: string, updateUserDto: any): Promise<User> {


### PR DESCRIPTION
## 추가한 점
- Access token의 payload 설정

### /chat
- 관련 DTO 추가
- 채팅방 생성 기능 추가
- 각 채팅방 별 읽지 않은 메세지 수 계산 기능 추가

### /chat/room
- 메세지 불러오기 기능 추가
- 메세지 별 읽지 않은 사람 수 계산 기능 추가
- 메세지 보내기 기능 추가
- 채팅방 참여 기능 추가

## 수정한 점
- SwaggerUI 재정비
- 개발의 편의성을 위해 access token의 만료기간을 30분으로 임시 설정 (추후 환경변수로 수정 예정)