### PR TITLE
fix: 메세지 조회 시 잘못된 index를 기준으로 조회하는 에러 수정

### DIFF
--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -66,19 +66,15 @@ export class ChatService {
     return chats;
   }
 
-  async markMessagesAsRead(
-    message: MarkMessagesAsReadDto
-  ): Promise<RoomDocument> {
+  async markMessagesAsRead(message): Promise<RoomDocument> {
     const { roomId, userId, lastMessageId } = message;
     const room = await this.roomModel.findById(roomId);
     room.lastReadMessage.set(userId, lastMessageId);
     return await room.save();
   }
 
-  async getUnreadMessageCount(
-    roomId: Types.ObjectId,
-    userId: Types.ObjectId
-  ): Promise<number> {
+  async getUnreadMessageCount(data: ChatUserDto): Promise<number> {
+    const { roomId, userId } = data;
     const room = await this.roomModel.findById(roomId).exec();
     const lastReadMessageId = room.lastReadMessage.get(userId);
     if (!lastReadMessageId) {
@@ -103,12 +99,13 @@ export class ChatService {
   /**
    * 각 채팅방 별 읽지 않은 메세지 수
    * @param roomId
+   * @param limit
    * @returns unreadCounts
    */
   async getUnreadCountForMessages(
     data: UnreadMessageReqDto
   ): Promise<UnreadMessageResDto> {
-    const roomId = data.roomId;
+    const { roomId, limit } = data;
     const room = await this.roomModel
       .findById(roomId)
       .populate('participants')
@@ -116,8 +113,9 @@ export class ChatService {
 
     // 해당 방에 존재하는 모든 메시지들을 가져옴
     const messages = await this.chatModel
-      .find({ roomId })
+      .find({ roomId: roomId })
       .sort({ createdAt: 'ascending' })
+      .limit(limit)
       .exec();
 
     // 메시지별로 읽지 않은 사람 수를 저장할 객체
@@ -125,12 +123,11 @@ export class ChatService {
 
     // 방의 참여자 정보와 각 참여자의 마지막 읽은 메시지를 확인
     for (const message of messages) {
-      console.log(message);
       let unreadCount = 0;
 
-      for (const userId of room.participants) {
+      for (const user of room.participants) {
         // 사용자의 마지막 읽은 메시지 ID
-        const lastReadMessageId = room.lastReadMessage.get(userId);
+        const lastReadMessageId = room.lastReadMessage.get(user._id);
 
         // lastReadMessageId가 없거나 현재 메시지 ID보다 이전이면 아직 읽지 않음
         if (
@@ -144,8 +141,6 @@ export class ChatService {
       // 메시지별로 읽지 않은 사람 수를 기록
       unreadCounts[message._id as string] = unreadCount;
     }
-
-    console.log(unreadCounts);
     return unreadCounts;
   }
   // TODO: 전체 조회 시 count 갱신과 채팅 하나 입력마다 새로 계산되는 것 다르게 구현

--- a/src/chat/dtos/chat.dto.ts
+++ b/src/chat/dtos/chat.dto.ts
@@ -25,7 +25,6 @@ export class ChatUserDto {
 
 export class MarkMessagesAsReadDto {
   roomId: Types.ObjectId;
-  userId: Types.ObjectId;
   lastMessageId: Types.ObjectId;
 }
 
@@ -40,6 +39,7 @@ export class UnreadChatResDto {
 
 export class UnreadMessageReqDto {
   roomId: Types.ObjectId;
+  limit: number;
 }
 
 export class UnreadMessageResDto {


### PR DESCRIPTION
## 수정한 점
- 클라이언트에서 user의 id를 넘겨줄 필요없이 토큰을 활용하도록 로직 수정

## 추가한 점
- 메세지 읽음 기능에 대한 API 추가