### PR TITLE
hotfix: 로그인 시 _id 대신 userId를 사용하도록 수정

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -35,7 +35,7 @@ export class AuthController {
   @Post('register')
   @ApiBody({ type: RegisterUserDto })
   async register(@Body() req: RegisterUserDto, @Res() res: Response) {
-    const user = await this.userService.findOne(req.userId);
+    const user = await this.userService.findByUserId(req.userId);
     if (user) {
       return res.json('User Id Already Exists');
     }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -14,7 +14,7 @@ export class AuthService {
   ) {}
 
   async validateUser(userId: string, pass: string): Promise<any> {
-    const user = await this.userService.findOne(userId);
+    const user = await this.userService.findByUserId(userId);
     if (
       user &&
       (await this.userService.validatePassword(pass, user.password))

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -12,6 +12,7 @@ import { UserService } from './user.service';
 import { UserDocument } from './schemas/user.schema';
 import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { Types } from 'mongoose';
 
 @UseGuards(JwtAuthGuard)
 @ApiBearerAuth()
@@ -31,7 +32,7 @@ export class UserController {
   }
 
   @Get(':id')
-  findOne(@Param('id') id: string) {
+  findOne(@Param('id') id: Types.ObjectId) {
     return this.userService.findOne(id).then((user: UserDocument) => {
       if (user) console.log(user.username);
     });

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -32,8 +32,12 @@ export class UserService {
     return this.userModel.find().exec();
   }
 
-  async findOne(id: string): Promise<UserDocument> {
+  async findOne(id: Types.ObjectId): Promise<UserDocument> {
     return await this.userModel.findOne({ _id: id }).exec();
+  }
+
+  async findByUserId(userId: string): Promise<UserDocument> {
+    return await this.userModel.findOne({ userId: userId }).exec();
   }
 
   async update(id: string, updateUserDto: any): Promise<User> {


### PR DESCRIPTION
## 추가한 점
- userId를 사용하여 user document를 조회할 수 있는 `findByUserId` 함수 추가

## 수정한 점
- 회원가입, 로그인 시 _id 대신 userId를 사용하여 조회하도록 수정