### PR TITLE
fix: 채팅 송수신 시 반환하는 데이터 수정

### DIFF
--- a/src/chat/chat.controller.ts
+++ b/src/chat/chat.controller.ts
@@ -25,6 +25,7 @@ import {
 import { ChatService } from './chat.service';
 import { RoomDocument } from './schemas/room.schemas';
 import { UserService } from 'src/user/user.service';
+import { ChatDocument } from './schemas/chat.schema';
 
 @UseGuards(JwtAuthGuard)
 @ApiBearerAuth()
@@ -83,7 +84,7 @@ export class ChatController {
   @Post('room/send')
   @ApiTags('Chat Room')
   @ApiBody({ type: SendMessageDto })
-  async send(@Body() req: SendMessageDto): Promise<RoomDocument> {
+  async send(@Body() req: SendMessageDto): Promise<ChatDocument> {
     return this.chatService.sendMessage(req);
   }
 

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -153,18 +153,18 @@ export class ChatService {
     return unreadCounts;
   }
 
-  async sendMessage(sended: SendMessageDto): Promise<RoomDocument> {
+  async sendMessage(sended: SendMessageDto): Promise<ChatDocument> {
     sended = {
       ...sended,
       createdAt: new Date(),
     } as ChatDocument;
-    return await this.chatModel.create(sended).then((chat) =>
-      this.markMessagesAsRead({
-        roomId: sended.roomId,
-        userId: sended.senderId,
-        lastMessageId: chat._id as Types.ObjectId,
-      } as MarkMessagesAsRead)
-    );
+    const chat = await this.chatModel.create(sended);
+    await this.markMessagesAsRead({
+      roomId: sended.roomId,
+      userId: sended.senderId,
+      lastMessageId: chat._id as Types.ObjectId,
+    } as MarkMessagesAsRead);
+    return chat;
   }
 
   async getTotalChat(data: GetChatReqDto): Promise<ChatResDto[]> {

--- a/src/user/dtos/user.dto.ts
+++ b/src/user/dtos/user.dto.ts
@@ -26,3 +26,11 @@ export class LoginUserDto {
   @IsString()
   readonly password: string;
 }
+
+export class changePasswordDto {
+  @IsString()
+  readonly prevPass: string;
+
+  @IsString()
+  readonly newPass: string;
+}

--- a/src/user/schemas/user.schema.ts
+++ b/src/user/schemas/user.schema.ts
@@ -31,7 +31,7 @@ export class User {
   tags: string[]; // 사용자 태그
 
   @Prop({ types: [Types.ObjectId], ref: 'Room' })
-  chats: Types.ObjectId[];
+  chats: Types.ObjectId[]; // 참여 중인 채팅방
 
   @Prop({ required: true, default: Date.now })
   @IsDate()


### PR DESCRIPTION
## 수정한 점
- 브로드캐스트를 진행하는 서버 명 수정
  - 기존 서버 명에 `room` 접두사가 붙어있지 않던 에러를 수정
- `readMessage` 시 각 메세지 별 읽지 않은 사람 수인 `counts`가 브로드캐스트되지 않도록 작성되어 있던 코드 수정